### PR TITLE
Removes unwanted newline at the end of examples.

### DIFF
--- a/source/main.js
+++ b/source/main.js
@@ -47,7 +47,7 @@ const MARKDOWN = {
   '<strong>': '**',
   '</strong>': '** ',
   '<pre>': '\n```\n',
-  '</pre>': '\n```\n\n',
+  '</pre>': '```\n\n',
   '<code>': '`',
   '</code>': '`',
   '&lt;': '<',


### PR DESCRIPTION
Sorry for cluttering your inbox with another pull request for such a small change.  I should have just done it in the previous pull.

Btw this extension is really helpful. Thank you.

| Before  | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/85361211/214287124-91502d40-6fd7-4c11-9d9c-236d86b3bd5f.png)  | ![image](https://user-images.githubusercontent.com/85361211/214287331-de6f33ec-a3f5-4b32-9a86-ea8e11f5770d.png) |
